### PR TITLE
fix(plugin): prevent runtime error if no globals in payload config

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -74,7 +74,7 @@ const payloadAiPlugin =
         }),
         endpoints: [...(incomingConfig.endpoints ?? []), endpoints.textarea, endpoints.upload],
         globals: [
-          ...incomingConfig.globals,
+          ...incomingConfig.globals || [],
           {
             slug: PLUGIN_INSTRUCTIONS_MAP_GLOBAL,
             access: {


### PR DESCRIPTION
`{...undefined}` will result in 

`Uncaught TypeError: undefined is not iterable`

This happens if the user does not have any existing globals in their payload config (and `incomingConfig.globals` is therefore `undefined`)