### PR TITLE
feat: access control config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Want to dive deeper?
 
 ### Other Features
 - 🎛️ **Field-level Prompt Customization**
+- 🔐 **Access Control Support**
 - 🧠 **Prompt Editor** (Beta)
 - 📊 **Document Analyzer** (Coming Soon)
 - ✅ **Fact Checking** (Coming Soon)
@@ -79,7 +80,15 @@ export default buildConfig({
         [Posts.slug]: true,
       },
       debugging: false,
-      disableSponsorMessage: false
+      disableSponsorMessage: false,
+
+     /* Enable to restrict access to AI plugin settings only to admin users
+      access: {
+        settings: ({ req }: { req: PayloadRequest }) => {
+          return req.user?.role === 'admin';
+        },
+      },
+      */
     }),
   ],
   // ... your existing Payload configuration
@@ -132,7 +141,6 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 If not specified, the [default](src/ai/models/openai/openai.ts) OpenAI endpoint will be used.
 
 For detailed guidance on personalizing and configuring the plugin to match your needs, check out the **[Complete Guide](guide.md)**. It walks you through every step, from setting up fields to generating amazing content!
-
 
 ### Enabling AI for Custom Components
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-stack/payloadcms",
-  "version": "3.2.8-beta",
+  "version": "3.2.9-beta",
   "private": false,
   "bugs": "https://github.com/ashbuilds/payload-ai/issues",
   "repository": "https://github.com/ashbuilds/payload-ai",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@ai-sdk/ui-utils": "^0.0.27",
     "@anthropic-ai/sdk": "^0.24.3",
     "ai": "^3.3.20",
+    "ajv": "^8.17.1",
     "elevenlabs": "^0.8.2",
     "get-input-selection": "^1.1.4",
     "handlebars": "4.7.8",
@@ -72,8 +73,7 @@
     "lodash.isequal": "^4.5.0",
     "openai": "^4.56.1",
     "scroll-into-view-if-needed": "^3.1.0",
-    "textarea-caret": "^3.0.2",
-    "ajv": "^8.17.1"
+    "textarea-caret": "^3.0.2"
   },
   "devDependencies": {
     "@eslint/compat": "^1.1.1",
@@ -105,12 +105,12 @@
     "typescript-eslint": "^7.18.0"
   },
   "peerDependencies": {
+    "@lexical/html": "^0.28.0",
     "@payloadcms/richtext-lexical": "^3.31.0",
     "@payloadcms/translations": "^3.31.0",
     "@payloadcms/ui": "^3.31.0",
-    "payload": "^3.31.0",
-    "@lexical/html": "^0.28.0",
-    "lexical": "^0.28.0"
+    "lexical": "^0.28.0",
+    "payload": "^3.31.0"
   },
   "publishConfig": {
     "main": "./dist/index.js",

--- a/src/collections/Instructions.ts
+++ b/src/collections/Instructions.ts
@@ -160,7 +160,6 @@ informative and accurate but also captivating and beautifully structured.`,
             label: 'System prompt',
           },
           {
-            // Note: Update when tabs PR is merged: https://github.com/payloadcms/payload/pull/8406
             admin: {
               condition: (_, current) => {
                 return current['field-type'] === 'richText'

--- a/src/collections/Instructions.ts
+++ b/src/collections/Instructions.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig, GroupField, PayloadRequest } from 'payload'
+import type { CollectionConfig, GroupField } from 'payload'
 import type { PluginConfig } from 'src/types.js'
 
 import { PLUGIN_INSTRUCTIONS_TABLE } from '../defaults.js'
@@ -120,7 +120,6 @@ export const instructionsCollection = (
         type: 'tabs',
         tabs: [
           {
-            // TODO: Add some info about the field to guide user
             description:
               'The Prompt field allows you to define dynamic templates using placeholders (e.g., {{ fieldName }}) to customize output based on your data fields.',
             fields: [
@@ -168,10 +167,10 @@ informative and accurate but also captivating and beautifully structured.`,
             description: '',
             fields: [
               {
-                /**TODO's:
+                /** TODO:
                  *  - Layouts can be saved in as an array
-                 *  - user can add their own layout to collections and use it later for generate specific rich text
-                 *  - user can select previously added layout
+                 *  - User can add their own layout to collections and use it later for generate specific rich text
+                 *  - User can select previously added layout
                  */
                 name: 'layout',
                 type: 'textarea',

--- a/src/collections/Instructions.ts
+++ b/src/collections/Instructions.ts
@@ -1,8 +1,8 @@
-import type { CollectionConfig, GroupField } from 'payload'
+import type { CollectionConfig, GroupField, PayloadRequest } from 'payload'
 import type { PluginConfig } from 'src/types.js'
 
-import { getGenerationModels } from '../utilities/getGenerationModels.js'
 import { PLUGIN_INSTRUCTIONS_TABLE } from '../defaults.js'
+import { getGenerationModels } from '../utilities/getGenerationModels.js'
 
 const groupSettings = (pluginConfig: PluginConfig) =>
   getGenerationModels(pluginConfig).reduce((fields, model) => {
@@ -139,16 +139,16 @@ export const instructionsCollection = (
             label: 'Prompt',
           },
           {
+            admin: {
+              condition: (_, current) => {
+                return current['field-type'] === 'richText'
+              },
+            },
             description: '',
             fields: [
               {
                 name: 'system',
                 type: 'textarea',
-                admin: {
-                  condition: (_, current) => {
-                    return current['field-type'] === 'richText'
-                  },
-                },
                 defaultValue: `INSTRUCTIONS:
 You are a highly skilled and professional blog writer,
 renowned for crafting engaging and well-organized articles.
@@ -161,12 +161,11 @@ informative and accurate but also captivating and beautifully structured.`,
           },
           {
             // Note: Update when tabs PR is merged: https://github.com/payloadcms/payload/pull/8406
-            // admin: {
-            //   condition: (_, current) => {
-            //     console.log('condition in tab', current)
-            //     return current['field-type'] === 'richText'
-            //   },
-            // },
+            admin: {
+              condition: (_, current) => {
+                return current['field-type'] === 'richText'
+              },
+            },
             description: '',
             fields: [
               {

--- a/src/endpoints/fetchFields.ts
+++ b/src/endpoints/fetchFields.ts
@@ -1,24 +1,41 @@
 import type { Endpoint, PayloadRequest } from 'payload'
 
+import type { PluginConfigAccess } from '../types.js'
+
 import { PLUGIN_FETCH_FIELDS_ENDPOINT, PLUGIN_INSTRUCTIONS_TABLE } from '../defaults.js'
 
-export const fetchFields: Endpoint = {
-  handler: async (req: PayloadRequest) => {
-    const { docs = [] } = await req.payload.find({
-      collection: PLUGIN_INSTRUCTIONS_TABLE,
-      pagination: false,
-    })
+export const fetchFields: (access: PluginConfigAccess) => Endpoint = (access) => {
+  return {
+    handler: async (req: PayloadRequest) => {
+      const { docs = [] } = await req.payload.find({
+        collection: PLUGIN_INSTRUCTIONS_TABLE,
+        pagination: false,
+      })
 
-    const fieldMap = {}
-    docs.forEach((doc) => {
-      fieldMap[doc['schema-path']] = {
-        id: doc.id,
-        fieldType: doc['field-type'],
+      let isConfigAllowed = true // Users allowed to update prompts by default
+
+      if (access?.settings) {
+        try {
+          isConfigAllowed = await access.settings({ req })
+        } catch (e) {
+          req.payload.logger.error('Please check your "access.settings" for request:', req)
+        }
       }
-    })
 
-    return Response.json(fieldMap)
-  },
-  method: 'get',
-  path: PLUGIN_FETCH_FIELDS_ENDPOINT,
+      const fieldMap = {}
+      docs.forEach((doc) => {
+        fieldMap[doc['schema-path']] = {
+          id: doc.id,
+          fieldType: doc['field-type'],
+        }
+      })
+
+      return Response.json({
+        fields: fieldMap,
+        isConfigAllowed,
+      })
+    },
+    method: 'get',
+    path: PLUGIN_FETCH_FIELDS_ENDPOINT,
+  }
 }

--- a/src/fields/ComposeField/ComposeField.tsx
+++ b/src/fields/ComposeField/ComposeField.tsx
@@ -8,7 +8,7 @@ import { Compose } from '../../ui/Compose/Compose.js'
 
 export const ComposeField = (props) => {
 
-  const { id: instructionId } = useInstructions({
+  const { id: instructionId, isConfigAllowed } = useInstructions({
     schemaPath: props?.schemaPath,
   })
 
@@ -20,7 +20,7 @@ export const ComposeField = (props) => {
         schemaPath: props?.schemaPath,
       }}
     >
-      <Compose descriptionProps={props} instructionId={instructionId} />
+      <Compose descriptionProps={props} instructionId={instructionId} isConfigAllowed={isConfigAllowed} />
     </FieldProvider>
   )
 }

--- a/src/fields/LexicalEditor/ComposeFeatureComponent.tsx
+++ b/src/fields/LexicalEditor/ComposeFeatureComponent.tsx
@@ -5,7 +5,7 @@ import { useInstructions } from '../../providers/InstructionsProvider/useInstruc
 import { Compose } from '../../ui/Compose/Compose.js'
 
 export const ComposeFeatureComponent = (props: any) => {
-  const { id: instructionId } = useInstructions({
+  const { id: instructionId, isConfigAllowed } = useInstructions({
     schemaPath: props?.clientProps?.schemaPath,
   })
 
@@ -25,6 +25,7 @@ export const ComposeFeatureComponent = (props: any) => {
           ...props?.clientProps,
         }}
         instructionId={instructionId}
+        isConfigAllowed={isConfigAllowed}
       />
     </FieldProvider>
   )

--- a/src/init.ts
+++ b/src/init.ts
@@ -8,7 +8,9 @@ import { PLUGIN_INSTRUCTIONS_TABLE } from './defaults.js'
 import { getGenerationModels } from './utilities/getGenerationModels.js'
 
 export const init = async (payload: Payload, fieldSchemaPaths, pluginConfig: PluginConfig) => {
-  payload.logger.info(`— AI Plugin: Initializing...`)
+  if (pluginConfig.debugging) {
+    payload.logger.info(`— AI Plugin: Initializing...`)
+  }
 
   const paths = Object.keys(fieldSchemaPaths)
 
@@ -68,7 +70,7 @@ export const init = async (payload: Payload, fieldSchemaPaths, pluginConfig: Plu
         })
         .then((a) => a)
         .catch((err) => {
-          console.log('— AI Plugin: Error creating Compose settings-', err)
+          payload.logger.error('— AI Plugin: Error creating Compose settings-', err)
         })
 
       // @ts-expect-error
@@ -91,9 +93,9 @@ export const init = async (payload: Payload, fieldSchemaPaths, pluginConfig: Plu
     payload.logger.info(
       `— AI Plugin: Enabled fields map: ${JSON.stringify(fieldInstructionsMap, null, 2)}`,
     )
+    payload.logger.info(`— AI Plugin: Initialized!`)
   }
 
-  payload.logger.info(`— AI Plugin: Initialized!`)
   if (pluginConfig.generatePromptOnInit) {
     payload.logger.info(
       '\n\n-AI Plugin: Example prompts are added to get you started, Now go break some code 🚀🚀🚀\n\n',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,7 @@ import { deepMerge } from 'payload/shared'
 
 import type { PluginConfig } from './types.js'
 
+import { defaultGenerationModels } from './ai/models/index.js'
 import { lexicalJsonSchema } from './ai/schemas/lexicalJsonSchema.js'
 import { instructionsCollection } from './collections/Instructions.js'
 import { PLUGIN_NAME } from './defaults.js'
@@ -11,16 +12,15 @@ import { fetchFields } from './endpoints/fetchFields.js'
 import { endpoints } from './endpoints/index.js'
 import { init } from './init.js'
 import { translations } from './translations/index.js'
+import { getGenerationModels } from './utilities/getGenerationModels.js'
 import { isPluginActivated } from './utilities/isPluginActivated.js'
 import { updateFieldsConfig } from './utilities/updateFieldsConfig.js'
-import { defaultGenerationModels } from './ai/models/index.js'
-import { getGenerationModels } from './utilities/getGenerationModels.js'
 
 const defaultPluginConfig: PluginConfig = {
   collections: {},
   disableSponsorMessage: false,
   generatePromptOnInit: true,
-  generationModels: defaultGenerationModels
+  generationModels: defaultGenerationModels,
 }
 
 const sponsorMessage = `
@@ -108,7 +108,7 @@ const payloadAiPlugin =
           ...(incomingConfig.endpoints ?? []),
           pluginEndpoints.textarea,
           pluginEndpoints.upload,
-          fetchFields,
+          fetchFields(pluginConfig.access),
         ],
         i18n: {
           ...(incomingConfig.i18n || {}),

--- a/src/providers/InstructionsProvider/InstructionsProvider.tsx
+++ b/src/providers/InstructionsProvider/InstructionsProvider.tsx
@@ -2,7 +2,7 @@
 
 import type { Field } from 'payload'
 
-import { useConfig } from '@payloadcms/ui'
+import { useAuth, useConfig } from '@payloadcms/ui'
 import React, { createContext, useEffect, useState } from 'react'
 
 import { PLUGIN_FETCH_FIELDS_ENDPOINT } from '../../defaults.js'
@@ -10,11 +10,13 @@ import { PLUGIN_FETCH_FIELDS_ENDPOINT } from '../../defaults.js'
 const initialContext: {
   field?: Field
   instructions: Record<string, any>
+  isConfigAllowed: boolean
   path?: string
   schemaPath?: unknown
 } = {
   field: undefined,
   instructions: undefined,
+  isConfigAllowed: true,
   path: '',
   schemaPath: '',
 }
@@ -23,6 +25,10 @@ export const InstructionsContext = createContext(initialContext)
 
 export const InstructionsProvider: React.FC = ({ children }: { children: React.ReactNode }) => {
   const [instructions, setInstructionsState] = useState({})
+  const [isConfigAllowed, setIsConfigAllowed] = useState(false)
+  const {
+    user
+  } = useAuth();
 
   const { config } = useConfig()
   const {
@@ -36,15 +42,16 @@ export const InstructionsProvider: React.FC = ({ children }: { children: React.R
     fetch(`${serverURL}${api}${PLUGIN_FETCH_FIELDS_ENDPOINT}`)
       .then(async (res) => {
         await res.json().then((data) => {
-          setInstructionsState(data)
+          setIsConfigAllowed(data?.isConfigAllowed)
+          setInstructionsState(data?.fields)
         })
       })
       .catch((err) => {
         console.error('InstructionsProvider:', err)
       })
-  }, [])
+  }, [user])
 
   return (
-    <InstructionsContext.Provider value={{ instructions }}>{children}</InstructionsContext.Provider>
+    <InstructionsContext.Provider value={{ instructions, isConfigAllowed }}>{children}</InstructionsContext.Provider>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,15 @@
 import type { JSONSchema } from 'openai/lib/jsonschema'
-import type { Endpoint, Field, GroupField } from 'payload'
+import type { Endpoint, Field, GroupField, PayloadRequest } from 'payload'
 import type { CSSProperties, MouseEventHandler } from 'react'
 
+export interface PluginConfigAccess {
+  settings?: ({ req }: {
+    req: PayloadRequest;
+  }) => Promise<boolean> | boolean;
+}
+
 export interface PluginConfig {
+  access?: PluginConfigAccess
   collections: {
     [key: string]: boolean
   }
@@ -18,13 +25,13 @@ export interface PluginConfig {
 
 export interface GenerationModel {
   fields: string[]
+  generateText?: (prompt: string, system: string) => Promise<string>
   handler?: (prompt: string, options: any) => Promise<any>
   id: string
   name: string
   output: 'audio' | 'file' | 'image' | 'json' | 'text' | 'video'
   settings?: GroupField
   supportsPromptOptimization?: boolean
-  generateText?: (prompt: string, system: string) => Promise<string>
 }
 
 export interface GenerationConfig {
@@ -74,6 +81,10 @@ export type ActionMenuEvents =
 
 export type UseMenuEvents = {
   [key in ActionMenuEvents]?: (data?: unknown) => void
+}
+
+export type UseMenuOptions = {
+  isConfigAllowed: boolean
 }
 
 export type BaseItemProps<T = any> = {

--- a/src/ui/Compose/Compose.tsx
+++ b/src/ui/Compose/Compose.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import type { ClientField } from 'payload'
-import { FC, useMemo } from 'react'
+import type { FC } from 'react'
 
 import { useEditorConfigContext } from '@payloadcms/richtext-lexical/client'
 import { FieldDescription, Popup, useDocumentDrawer, useField } from '@payloadcms/ui'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PLUGIN_INSTRUCTIONS_TABLE } from '../../defaults.js'
 import { setSafeLexicalState } from '../../utilities/setSafeLexicalState.js'
@@ -37,9 +37,10 @@ type ComposeProps = {
     schemaPath: string
   }
   instructionId: string
+  isConfigAllowed: boolean
 }
 
-export const Compose: FC<ComposeProps> = ({ descriptionProps, instructionId }) => {
+export const Compose: FC<ComposeProps> = ({ descriptionProps, instructionId, isConfigAllowed }) => {
   const [DocumentDrawer, _, { closeDrawer, openDrawer }] = useDocumentDrawer({
     id: instructionId,
     collectionSlug: PLUGIN_INSTRUCTIONS_TABLE,
@@ -134,7 +135,7 @@ export const Compose: FC<ComposeProps> = ({ descriptionProps, instructionId }) =
         action: 'Rephrase',
       })
     },
-    onSettings: openDrawer,
+    onSettings: isConfigAllowed ? openDrawer : undefined,
     onSimplify: async () => {
       console.log('Simplifying...')
       await generate({
@@ -154,6 +155,8 @@ export const Compose: FC<ComposeProps> = ({ descriptionProps, instructionId }) =
         params: data,
       })
     },
+  },{
+    isConfigAllowed
   })
 
   const { setValue } = useField<string>({

--- a/src/ui/Compose/hooks/menu/TranslateMenu.tsx
+++ b/src/ui/Compose/hooks/menu/TranslateMenu.tsx
@@ -33,7 +33,10 @@ export const TranslateMenu = ({ onClick }) => {
         onMouseEnter={() => setShow(true)}
        />
       <div className={styles.hoverMenu} data-show={show}>
-        <div className={`${styles.menu} ${styles.subMenu}`}>
+        <div className={`${styles.menu} ${styles.subMenu}`} style={{
+          background: "var(--popup-bg)",
+          minHeight: "300px"
+        }}>
           <Item
             onClick={() => {}}
             style={{

--- a/src/ui/Compose/hooks/menu/useMenu.tsx
+++ b/src/ui/Compose/hooks/menu/useMenu.tsx
@@ -3,7 +3,7 @@
 import { useField } from '@payloadcms/ui'
 import React, { useEffect, useMemo, useState } from 'react'
 
-import type { ActionMenuItems, UseMenuEvents } from '../../../../types.js'
+import { ActionMenuItems, UseMenuEvents, UseMenuOptions } from '../../../../types.js'
 
 import { useFieldProps } from '../../../../providers/FieldProvider/useFieldProps.js'
 import { Compose, Proofread, Rephrase } from './items.js'
@@ -23,7 +23,7 @@ const getActiveComponent = (ac) => {
   }
 }
 
-export const useMenu = (menuEvents: UseMenuEvents) => {
+export const useMenu = (menuEvents: UseMenuEvents, options: UseMenuOptions) => {
   const { type: fieldType, path: pathFromContext } = useFieldProps()
   const field = useField({ path: pathFromContext })
   const [activeComponent, setActiveComponent] = useState<ActionMenuItems>('Rephrase')
@@ -77,9 +77,12 @@ export const useMenu = (menuEvents: UseMenuEvents) => {
 
   const filteredMenuItems = useMemo(
     () =>
-      menuItemsMap.filter((i) => i.name !== activeComponent && !i.excludedFor?.includes(fieldType)),
-    [activeComponent, fieldType],
-  )
+      menuItemsMap.filter((i) => {
+        if (i.name === 'Settings' && !options.isConfigAllowed) return false; // Disable settings if a user role is not permitted
+        return i.name !== activeComponent && !i.excludedFor?.includes(fieldType);
+      }),
+    [activeComponent, fieldType, options.isConfigAllowed],
+  );
 
   const MemoizedMenu = useMemo(() => {
     return ({ isLoading, onClose }) => (
@@ -95,7 +98,7 @@ export const useMenu = (menuEvents: UseMenuEvents) => {
                   setActiveComponent(i.name)
                 }
 
-                menuEvents[`on${i.name}`](data)
+                menuEvents[`on${i.name}`]?.(data)
                 onClose()
               }}
             >

--- a/src/utilities/isPluginActivated.ts
+++ b/src/utilities/isPluginActivated.ts
@@ -1,5 +1,6 @@
+import type { PluginConfig } from '../types.js'
+
 import { getGenerationModels } from './getGenerationModels.js'
-import { PluginConfig } from '../types.js'
 
 export const isPluginActivated = (pluginConfig: PluginConfig) => {
   return getGenerationModels(pluginConfig).length > 0


### PR DESCRIPTION
To restrict access to the **Settings** menu in the admin panel for specific users, you can use the `access` control in your plugin configuration. For example, to allow only users with the role `admin` to access settings, update your config as follows:

```ts
payloadAiPlugin({
  // ... your existing plugin config
  access: {
    settings: ({ req }) => {
      return req.user?.role === 'admin';
    },
  },
})
```