### PR TITLE
[feat] add locale filtering using enabledLanguages in plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ export default buildConfig({
       },
 
       options: {
-        // Visit locale-codes for tags:
+        // Visit locale-codes for tags, 
+        // defaults to display all language options for Translate feature
         // https://www.npmjs.com/package/locale-codes
         enabledLanguages: ["en-US", "zh-SG", "zh-CN", "en"],
       },

--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ export default buildConfig({
         settings: ({ req }) => req.user?.role === 'admin',
       },
 
+      options: {
+        // Visit locale-codes for tags:
+        // https://www.npmjs.com/package/locale-codes
+        enabledLanguages: ["en-US", "zh-SG", "zh-CN", "en"],
+      },
+
       // Optional: Custom media upload handling, useful for multi-tenant setups
       mediaUpload: async (result, { request, collection }) => {
         return request.payload.create({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-stack/payloadcms",
-  "version": "3.2.15-beta",
+  "version": "3.2.16-beta",
   "private": false,
   "bugs": "https://github.com/ashbuilds/payload-ai/issues",
   "repository": "https://github.com/ashbuilds/payload-ai",

--- a/src/endpoints/fetchFields.ts
+++ b/src/endpoints/fetchFields.ts
@@ -1,10 +1,13 @@
 import type { Endpoint, PayloadRequest } from 'payload'
 
-import type { PluginConfigAccess } from '../types.js'
+import type { PluginConfigAccess, PluginOptions } from '../types.js'
 
 import { PLUGIN_FETCH_FIELDS_ENDPOINT, PLUGIN_INSTRUCTIONS_TABLE } from '../defaults.js'
 
-export const fetchFields: (access: PluginConfigAccess) => Endpoint = (access) => {
+export const fetchFields: (access: PluginConfigAccess, options?: PluginOptions) => Endpoint = (
+  access,
+  options = {},
+) => {
   return {
     handler: async (req: PayloadRequest) => {
       const { docs = [] } = await req.payload.find({
@@ -31,6 +34,7 @@ export const fetchFields: (access: PluginConfigAccess) => Endpoint = (access) =>
       })
 
       return Response.json({
+        ...options,
         fields: fieldMap,
         isConfigAllowed,
       })

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -139,7 +139,7 @@ const payloadAiPlugin =
             ...(incomingConfig.endpoints ?? []),
             pluginEndpoints.textarea,
             pluginEndpoints.upload,
-            fetchFields(pluginConfig.access),
+            fetchFields(pluginConfig.access, pluginConfig.options),
           ],
           globals: globals.map((global) => {
             if (globalsSlugs[global.slug]) {

--- a/src/providers/InstructionsProvider/InstructionsProvider.tsx
+++ b/src/providers/InstructionsProvider/InstructionsProvider.tsx
@@ -9,6 +9,7 @@ import { PLUGIN_FETCH_FIELDS_ENDPOINT } from '../../defaults.js'
 
 const initialContext: {
   activeCollection?: string
+  enabledLanguages?: string[]
   field?: Field
   instructions: Record<string, any>
   isConfigAllowed: boolean
@@ -29,6 +30,7 @@ export const InstructionsProvider: React.FC = ({ children }: { children: React.R
   const [instructions, setInstructionsState] = useState({})
   const [activeCollection, setActiveCollection] = useState('')
   const [isConfigAllowed, setIsConfigAllowed] = useState(false)
+  const [enabledLanguages, setEnabledLanguages] = useState<string[]>()
   const { user } = useAuth()
 
   const { config } = useConfig()
@@ -44,6 +46,7 @@ export const InstructionsProvider: React.FC = ({ children }: { children: React.R
       .then(async (res) => {
         await res.json().then((data) => {
           setIsConfigAllowed(data?.isConfigAllowed)
+          setEnabledLanguages(data?.enabledLanguages)
           setInstructionsState(data?.fields)
         })
       })
@@ -54,7 +57,13 @@ export const InstructionsProvider: React.FC = ({ children }: { children: React.R
 
   return (
     <InstructionsContext.Provider
-      value={{ activeCollection, instructions, isConfigAllowed, setActiveCollection }}
+      value={{
+        activeCollection,
+        enabledLanguages,
+        instructions,
+        isConfigAllowed,
+        setActiveCollection,
+      }}
     >
       {children}
     </InstructionsContext.Provider>

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,17 @@ export interface PluginConfigAccess {
   settings?: ({ req }: { req: PayloadRequest }) => Promise<boolean> | boolean
 }
 
+export interface PluginOptions {
+
+  /**
+   * Provide local tags to filter language options from the Translate Menu
+   * Check for the available local tags,
+   * visit: https://www.npmjs.com/package/locale-codes
+   * Example: ["en-US", "zh-SG", "zh-CN", "en"]
+   */
+  enabledLanguages?: string[]
+}
+
 export type PluginConfigMediaUploadFunction = (
   result: { data: Record<any, any>; file: File },
   {
@@ -56,6 +67,7 @@ export interface PluginConfig {
   }
   interfaceName?: string
   mediaUpload?: PluginConfigMediaUploadFunction
+  options?: PluginOptions
   uploadCollectionSlug?: CollectionSlug
 }
 

--- a/src/ui/Compose/hooks/menu/TranslateMenu.tsx
+++ b/src/ui/Compose/hooks/menu/TranslateMenu.tsx
@@ -1,6 +1,7 @@
 import locales from 'locale-codes'
-import React, { useState } from 'react'
+import React, { memo, useState } from 'react'
 
+import { useInstructions } from '../../../../providers/InstructionsProvider/useInstructions.js'
 import { Item } from './Item.js'
 import { Translate } from './items.js'
 import styles from './menu.module.scss'
@@ -8,9 +9,15 @@ import styles from './menu.module.scss'
 export const TranslateMenu = ({ onClick }) => {
   const [show, setShow] = useState(false)
 
-  const filteredLocales = locales.all.filter((a) => {
+  const { enabledLanguages = [] } = useInstructions()
+
+  let filteredLocales = locales.all.filter((a) => {
     return a.tag && a.location
   })
+
+  if (enabledLanguages?.length) {
+    filteredLocales = filteredLocales.filter((a) => enabledLanguages?.includes(a.tag))
+  }
 
   const [languages, setLanguages] = useState(filteredLocales)
   const [inputFocus, setInputFocus] = useState(false)
@@ -31,12 +38,15 @@ export const TranslateMenu = ({ onClick }) => {
           setShow(!show)
         }}
         onMouseEnter={() => setShow(true)}
-       />
+      />
       <div className={styles.hoverMenu} data-show={show}>
-        <div className={`${styles.menu} ${styles.subMenu}`} style={{
-          background: "var(--popup-bg)",
-          minHeight: "300px"
-        }}>
+        <div
+          className={`${styles.menu} ${styles.subMenu}`}
+          style={{
+            background: 'var(--popup-bg)',
+            // minHeight: '300px',
+          }}
+        >
           <Item
             onClick={() => {}}
             style={{
@@ -83,3 +93,5 @@ export const TranslateMenu = ({ onClick }) => {
     </div>
   )
 }
+
+export const MemoizedTranslateMenu = memo(TranslateMenu)

--- a/src/ui/Compose/hooks/menu/itemsMap.ts
+++ b/src/ui/Compose/hooks/menu/itemsMap.ts
@@ -2,7 +2,7 @@ import type React from 'react'
 
 import type { ActionMenuItems, BaseItemProps } from '../../../../types.js'
 
-import { TranslateMenu } from './TranslateMenu.js'
+import { MemoizedTranslateMenu, TranslateMenu } from './TranslateMenu.js'
 import { Compose, Expand, Proofread, Rephrase, Settings, Simplify, Summarize } from './items.js'
 
 type MenuItemsMapType = {
@@ -17,7 +17,7 @@ export const menuItemsMap: MenuItemsMapType[] = [
   { name: 'Rephrase', component: Rephrase, excludedFor: ['upload'], loadingText: 'Rephrasing' },
   {
     name: 'Translate',
-    component: TranslateMenu,
+    component: MemoizedTranslateMenu,
     excludedFor: ['upload'],
     loadingText: 'Translating',
   },


### PR DESCRIPTION
**Main Changes:**

- Adds an enabledLanguages option to the plugin configuration that accepts an array of locale codes (e.g., `["en-US", "zh-SG", "zh-CN", "en"]`)
- Filters the translate menu to only show languages specified in the configuration
- If no enabledLanguages are configured, it shows all available locales as before

```
import { payloadAI } from '@ai-stack/payloadcms'

export default buildConfig({
  plugins: [
    payloadAI({
      // ... other plugin config
      options: {
        // Only show these languages in the translate menu
        enabledLanguages: ["en-US", "es-ES", "fr-FR", "de-DE", "ja-JP"]
      }
    })
  ],
  // ... rest of your config
})
```

**Available locale codes:**
You can find all available locale codes at: [locale-codes](https://www.npmjs.com/package/locale-codes)
