### PR TITLE
Properly print errors first, so they're serialized by pino

### DIFF
--- a/src/endpoints/fetchFields.ts
+++ b/src/endpoints/fetchFields.ts
@@ -21,7 +21,7 @@ export const fetchFields: (access: PluginConfigAccess, options?: PluginOptions) 
         try {
           isConfigAllowed = await access.settings({ req })
         } catch (e) {
-          req.payload.logger.error('Please check your "access.settings" for request:', req)
+          req.payload.logger.error(req, 'Please check your "access.settings" for request')
         }
       }
 

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -194,7 +194,7 @@ export const endpoints: (pluginConfig: PluginConfig) => Endpoints = (pluginConfi
             system: prompts.system,
           })
         } catch (error) {
-          req.payload.logger.error('Error generating content: ', error)
+          req.payload.logger.error(error, 'Error generating content: ')
           return new Response(JSON.stringify({ error: error.message }), {
             headers: { 'Content-Type': 'application/json' },
             status:
@@ -229,7 +229,7 @@ export const endpoints: (pluginConfig: PluginConfig) => Endpoints = (pluginConfi
                 req, // Pass req to ensure access control is applied
               })
             } catch (e) {
-              req.payload.logger.error(
+              req.payload.logger.error(e, 
                 '— AI Plugin: Error fetching document, you should try again after enabling drafts for this collection',
               )
             }
@@ -288,8 +288,7 @@ export const endpoints: (pluginConfig: PluginConfig) => Endpoints = (pluginConfi
                 url: `${serverURL}${img.image.url}`,
               })
             } catch (e) {
-              req.payload.logger.error('Error fetching reference images!')
-              console.error(e)
+              req.payload.logger.error(e, 'Error fetching reference images!')
               throw Error(
                 "We couldn't fetch the images. Please ensure the images are accessible and hosted publicly.",
               )
@@ -343,7 +342,7 @@ export const endpoints: (pluginConfig: PluginConfig) => Endpoints = (pluginConfi
             }),
           )
         } catch (error) {
-          req.payload.logger.error('Error generating upload: ', error)
+          req.payload.logger.error(error, 'Error generating upload: ')
           return new Response(JSON.stringify({ error: error.message }), {
             headers: { 'Content-Type': 'application/json' },
             status:

--- a/src/init.ts
+++ b/src/init.ts
@@ -70,7 +70,7 @@ export const init = async (payload: Payload, fieldSchemaPaths, pluginConfig: Plu
         })
         .then((a) => a)
         .catch((err) => {
-          payload.logger.error('— AI Plugin: Error creating Compose settings-', err)
+          payload.logger.error(err, '— AI Plugin: Error creating Compose settings-')
         })
 
       // @ts-expect-error

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -172,8 +172,7 @@ const payloadAiPlugin =
 
         await init(payload, collectionsFieldPathMap, pluginConfig)
           .catch((error) => {
-            console.error(error)
-            payload.logger.error(`— AI Plugin: Initialization Error: ${error}`)
+            payload.logger.error(error, `— AI Plugin: Initialization Error`)
           })
           .finally(() => {
             setTimeout(() => {


### PR DESCRIPTION
This pull request refactors how errors are logged throughout the codebase to standardize the order of arguments passed to the logger. 

Now, the error object is consistently passed as the first argument, followed by the message. This is the supported way of including structured data in logs by pino - which is used by payload for logging.
