### PR TITLE
Allow configuration of prompts and prompt seeder

### DIFF
--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -1,17 +1,4 @@
-import type { ActionMenuItems } from '../types.js'
-
-type ActionPromptOptions = {
-  layout?: string
-  locale?: string
-  prompt?: string
-  systemPrompt?: string
-}
-
-type ActionPrompt = {
-  layout?: (options?: ActionPromptOptions) => string
-  name: ActionMenuItems
-  system: (options: ActionPromptOptions) => string
-}
+import type { ActionPrompt, SeedPromptFunction } from '../types.js'
 
 //TODO: This is a temporary solution make use of structured output
 export const defaultSystemPrompt = `IMPORTANT INSTRUCTION:
@@ -127,7 +114,7 @@ INSTRUCTIONS:
   },
 ]
 
-export const seedPrompts = ({ fieldLabel, fieldSchemaPaths, fieldType, path }) => {
+export const defaultSeedPrompts: SeedPromptFunction = ({ fieldLabel, fieldSchemaPaths, fieldType, path }) => {
   return {
     prompt: `field-type: ${fieldType}
 field-name: ${fieldLabel}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -47,6 +47,7 @@ const assignPrompt = async (
     field,
     layout,
     locale,
+    pluginConfig,
     systemPrompt = '',
     template,
   }: {
@@ -55,10 +56,11 @@ const assignPrompt = async (
     field: string
     layout: string
     locale: string
+    pluginConfig: PluginConfig,
     systemPrompt: string
     template: string
     type: string
-  },
+  },  
 ) => {
   const prompt = await replacePlaceholders(template, context)
   const toLexicalHTML = type === 'richText' ? handlebarsHelpersMap.toHTML.name : ''
@@ -86,7 +88,8 @@ const assignPrompt = async (
     return assignedPrompts
   }
 
-  const { layout: getLayout, system: getSystemPrompt } = defaultPrompts.find(
+  const prompts = [...pluginConfig.prompts || [], ...defaultPrompts]
+  const { layout: getLayout, system: getSystemPrompt } = prompts.find(
     (p) => p.name === action,
   )
 
@@ -182,6 +185,7 @@ export const endpoints: (pluginConfig: PluginConfig) => Endpoints = (pluginConfi
             field: fieldName,
             layout: instructions.layout,
             locale: localeInfo,
+            pluginConfig,
             systemPrompt: instructions.system,
             template: promptTemplate as string,
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,7 @@
 
 import { PayloadAiPluginLexicalEditorFeature } from './fields/LexicalEditor/feature.server.js'
 
+export { defaultPrompts, defaultSeedPrompts as seedPrompts } from './ai/prompts.js'
+
 export { payloadAiPlugin } from './plugin.js'
 export { PayloadAiPluginLexicalEditorFeature }

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,7 +2,7 @@ import type { Payload } from 'payload'
 
 import type { PluginConfig } from './types.js'
 
-import { seedPrompts } from './ai/prompts.js'
+import { defaultSeedPrompts } from './ai/prompts.js'
 import { systemGenerate } from './ai/utils/systemGenerate.js'
 import { PLUGIN_INSTRUCTIONS_TABLE } from './defaults.js'
 import { getGenerationModels } from './utilities/getGenerationModels.js'
@@ -32,6 +32,7 @@ export const init = async (payload: Payload, fieldSchemaPaths, pluginConfig: Plu
     })
 
     if (!entry?.docs?.length) {
+      const seedPrompts = pluginConfig.seedPrompts || defaultSeedPrompts
       const { prompt, system } = seedPrompts({
         fieldLabel,
         fieldSchemaPaths,

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,18 @@ export interface PluginConfig {
   interfaceName?: string
   mediaUpload?: PluginConfigMediaUploadFunction
   options?: PluginOptions
+  /**
+   * Custom action prompts for AI text generation
+   * If not provided, uses default prompts
+   * You can access default prompts by importing { defaultPrompts } from '@ai-stack/payloadcms'
+   */
+  prompts?: ActionPrompt[]
+  /**
+   * Custom seed prompt function for generating field-specific prompts
+   * If not provided, uses default seed prompt function
+   * You can access default seed prompts by importing { defaultSeedPrompts } from '@ai-stack/payloadcms'
+  */
+  seedPrompts?: SeedPromptFunction
   uploadCollectionSlug?: CollectionSlug
 }
 
@@ -110,6 +122,31 @@ export type ActionMenuItems =
   | 'Summarize'
   | 'Tone'
   | 'Translate'
+
+export type ActionPromptOptions = {
+  layout?: string
+  locale?: string
+  prompt?: string
+  systemPrompt?: string
+}
+
+export type ActionPrompt = {
+  layout?: (options?: ActionPromptOptions) => string
+  name: ActionMenuItems
+  system: (options: ActionPromptOptions) => string
+}
+
+export type SeedPromptOptions = {
+  fieldLabel: string
+  fieldSchemaPaths: Record<string, any>
+  fieldType: string
+  path: string
+}
+
+export type SeedPromptFunction = (options: SeedPromptOptions) => {
+  prompt: string
+  system: string
+}
 
 export type ActionMenuEvents =
   | 'onCompose'


### PR DESCRIPTION
Adds the ability to configure custom action prompts and seed prompt function. 
Users can now override default prompts and customize how field-specific prompts are generated.
Default prompts and seeder are exported, so can be referenced for modifications.