### PR TITLE
fix(elevenlabs): defer getAllVoices() to async options callback - removes top-level await

### DIFF
--- a/src/ai/models/elevenLabs/index.ts
+++ b/src/ai/models/elevenLabs/index.ts
@@ -1,30 +1,25 @@
 import type { Field, File } from 'payload'
 
 import type { GenerationConfig } from '../../../types.js'
-import type { Voice } from './voices.js'
 
 import { generateFileNameByPrompt } from '../../utils/generateFileNameByPrompt.js'
 import { generateVoice } from './generateVoice.js'
 import { getAllVoices } from './voices.js'
 
-const { voices = [] }: { voices: Voice[] } = await getAllVoices()
-
-const voiceOptions = voices.map((voice) => {
-  return {
-    label: voice.name ?? '',
-    value: voice.voice_id,
-    ...voice,
-  }
-})
-
-const fieldVoiceOptions = voiceOptions.map((option) => {
-  return {
-    label: option.name ?? '',
-    value: option.voice_id,
-  }
-})
-
 const fields: Field[] = [
+  {
+    name: 'voice_id',
+    type: 'select',
+    label: 'Voice',
+    options: async () => {
+      const { voices = [] } = await getAllVoices()
+      return voices.map((voice) => ({
+        label: voice.name ?? '',
+        value: voice.voice_id,
+      }))
+    },
+    required: true,
+  },
   {
     type: 'collapsible',
     admin: {
@@ -86,17 +81,6 @@ const fields: Field[] = [
     ],
   },
 ]
-
-if (voiceOptions.length) {
-  fields.unshift({
-    name: 'voice_id',
-    type: 'select',
-    defaultValue: voiceOptions[0]?.voice_id,
-    label: 'Voice',
-    options: fieldVoiceOptions,
-    required: true,
-  })
-}
 
 const MODEL_KEY = '11Labs'
 


### PR DESCRIPTION
## Problem

Discovered while integrating `@ai-stack/payloadcms` into a Next.js + Payload v3 project (otherdev.com). Running `generate:importmap` crashed immediately after adding `payloadAiPlugin` to `payload.config.ts`:

```
Error: Transform failed with 1 error:
node_modules/@ai-stack/payloadcms/dist/ai/models/elevenLabs/index.js:4:24:
ERROR: Top-level await is currently not supported with the "cjs" output format
```

**Root cause:** `src/ai/models/elevenLabs/index.ts` calls `getAllVoices()` at module scope via top-level `await`. Payload's `generate:importmap` bundles the config graph through esbuild with `format: "cjs"`, which cannot emit TLA. This breaks the command for every project using `payloadAiPlugin` — regardless of whether it uses ElevenLabs.

**Secondary issue:** the top-level call also fires a live ElevenLabs API request on every config parse, even in projects that don't use voice fields.

Tracked in issue #147.

## Fix

Payload's `select` field accepts `options` as an `async () => SelectOption[]` callback. Moving the `getAllVoices()` call there defers it to field-render time in the admin UI — no API call at module load, no esbuild conflict.

```diff
- const { voices = [] }: { voices: Voice[] } = await getAllVoices()
- const voiceOptions = voices.map((voice) => ({ label: voice.name ?? '', value: voice.voice_id, ...voice }))
- const fieldVoiceOptions = voiceOptions.map((o) => ({ label: o.name ?? '', value: o.voice_id }))

  const fields: Field[] = [
+   {
+     name: 'voice_id',
+     type: 'select',
+     label: 'Voice',
+     options: async () => {
+       const { voices = [] } = await getAllVoices()
+       return voices.map((voice) => ({ label: voice.name ?? '', value: voice.voice_id }))
+     },
+     required: true,
+   },
    { type: 'collapsible', ... },
  ]

- if (voiceOptions.length) {
-   fields.unshift({
-     name: 'voice_id',
-     type: 'select',
-     defaultValue: voiceOptions[0]?.voice_id,
-     label: 'Voice',
-     options: fieldVoiceOptions,
-     required: true,
-   })
- }
```

## Testing

- `generate:importmap` and `generate:types` complete without error
- Voice dropdown still renders correctly in the admin UI (options loaded on demand)
- No ElevenLabs API call occurs at config parse time
