### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Create a `.env` file in your project root. Add the keys for the providers you wa
 OPENAI_API_KEY=your-openai-api-key           # OpenAI models (GPT-4, etc.)
 ANTHROPIC_API_KEY=your-anthropic-api-key     # Claude models
 GOOGLE_GENERATIVE_AI_API_KEY=your-google-key # Gemini models
-MINIMAX_API_KEY=your-minimax-api-key         # MiniMax M2.7 / M2.5 models
+MINIMAX_API_KEY=your-minimax-api-key         # MiniMax M3 / M2.7 models
 
 # Image Generation - Choose your provider(s)
 OPENAI_API_KEY=your-openai-api-key           # DALL-E (uses same key as above)

--- a/src/ai/models/minimax/__tests__/minimax.test.ts
+++ b/src/ai/models/minimax/__tests__/minimax.test.ts
@@ -37,35 +37,34 @@ describe('minimax provider — unit', () => {
   })
 
   describe('model list', () => {
-    it('includes M2.7 and M2.5 variants', async () => {
+    it('includes M3 and M2.7 variants', async () => {
       const { MiniMaxConfig } = await import('../index.js')
       const textModel = MiniMaxConfig.models.find((m) => m.id === 'MINIMAX-text')
       const modelField = (textModel!.settings!.fields as any[]).find(
         (f: any) => f.name === 'model',
       )
       expect(modelField).toBeDefined()
+      expect(modelField.options).toContain('MiniMax-M3')
       expect(modelField.options).toContain('MiniMax-M2.7')
       expect(modelField.options).toContain('MiniMax-M2.7-highspeed')
-      expect(modelField.options).toContain('MiniMax-M2.5')
-      expect(modelField.options).toContain('MiniMax-M2.5-highspeed')
     })
 
-    it('defaults to MiniMax-M2.7 for text model', async () => {
+    it('defaults to MiniMax-M3 for text model', async () => {
       const { MiniMaxConfig } = await import('../index.js')
       const textModel = MiniMaxConfig.models.find((m) => m.id === 'MINIMAX-text')
       const modelField = (textModel!.settings!.fields as any[]).find(
         (f: any) => f.name === 'model',
       )
-      expect(modelField?.defaultValue).toBe('MiniMax-M2.7')
+      expect(modelField?.defaultValue).toBe('MiniMax-M3')
     })
 
-    it('defaults to MiniMax-M2.7 for object model', async () => {
+    it('defaults to MiniMax-M3 for object model', async () => {
       const { MiniMaxConfig } = await import('../index.js')
       const objectModel = MiniMaxConfig.models.find((m) => m.id === 'MINIMAX-object')
       const modelField = (objectModel!.settings!.fields as any[]).find(
         (f: any) => f.name === 'model',
       )
-      expect(modelField?.defaultValue).toBe('MiniMax-M2.7')
+      expect(modelField?.defaultValue).toBe('MiniMax-M3')
     })
   })
 
@@ -96,7 +95,7 @@ describe('minimax provider — unit', () => {
 
     it('returns a language model instance for a given model id', async () => {
       const { minimax } = await import('../minimax.js')
-      const model = minimax('MiniMax-M2.7')
+      const model = minimax('MiniMax-M3')
       expect(model).toBeDefined()
       expect(typeof model).toBe('object')
     })
@@ -142,7 +141,7 @@ describe.skipIf(!runIntegration)('minimax provider — integration', () => {
     }
 
     const response = await textModel.handler!('Say hello in one word', {
-      model: 'MiniMax-M2.7',
+      model: 'MiniMax-M3',
       maxTokens: 50,
       temperature: 0.5,
       schema,
@@ -185,7 +184,7 @@ describe.skipIf(!runIntegration)('minimax provider — integration', () => {
 
     // Should not throw despite temperature=0 being invalid for MiniMax
     const response = await textModel.handler!('What is 2+2?', {
-      model: 'MiniMax-M2.5',
+      model: 'MiniMax-M3',
       maxTokens: 50,
       temperature: 0, // will be clamped to 0.001
       schema,

--- a/src/ai/models/minimax/index.ts
+++ b/src/ai/models/minimax/index.ts
@@ -5,7 +5,7 @@ import { generateObject } from '../generateObject.js'
 import { minimax } from './minimax.js'
 
 const MODEL_KEY = 'MINIMAX'
-const MODELS = ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+const MODELS = ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']
 
 /**
  * MiniMax requires temperature in the range (0.0, 1.0].
@@ -57,7 +57,7 @@ export const MiniMaxConfig: GenerationConfig = {
           {
             name: 'model',
             type: 'select',
-            defaultValue: 'MiniMax-M2.7',
+            defaultValue: 'MiniMax-M3',
             label: 'Model',
             options: MODELS,
           },
@@ -114,7 +114,7 @@ export const MiniMaxConfig: GenerationConfig = {
           {
             name: 'model',
             type: 'select',
-            defaultValue: 'MiniMax-M2.7',
+            defaultValue: 'MiniMax-M3',
             label: 'Model',
             options: MODELS,
           },


### PR DESCRIPTION
## Summary
Upgrade the MiniMax provider's model configuration to include the new M3 model and set it as the default.

## Changes
- Add `MiniMax-M3` to the model selection list (placed first)
- Set `MiniMax-M3` as the new default for both `MINIMAX-text` and `MINIMAX-object` models
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` from the list
- Update unit and integration tests to reflect the new default
- Update README to mention M3 / M2.7 alongside `MINIMAX_API_KEY`

## Why
MiniMax-M3 is the latest flagship model with improved reasoning, a larger context window, and image input support. Users will get the upgraded model by default while still being able to fall back to M2.7 variants via the model selector.

## Testing
- Existing unit tests updated and structure preserved
- Integration tests parameterized with `MiniMax-M3`; gated by `MINIMAX_API_KEY` as before